### PR TITLE
Add web backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,10 +372,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -506,6 +536,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "h2"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +647,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -626,6 +676,19 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -753,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +951,24 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -945,10 +1038,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl"
+version = "0.10.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1057,6 +1188,12 @@ checksum = "0cbfce16d3b505cfe560e1278836e16f400274d04395773ceb7879029b409429"
 dependencies = [
  "parity-scale-codec",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1277,6 +1414,44 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "ring"
@@ -1549,6 +1724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,7 +1835,6 @@ dependencies = [
  "anyhow",
  "blake2",
  "bootcode",
- "futures-util",
  "hex",
  "hyper",
  "hyper-rustls",
@@ -1660,6 +1846,7 @@ dependencies = [
  "qjs-extensions",
  "qjsbind",
  "rand",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1670,7 +1857,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -1771,10 +1957,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "template-quote"
@@ -1873,6 +2093,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,6 +2110,20 @@ checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2013,6 +2257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,19 +2348,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "web-sys"
@@ -2244,6 +2481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +779,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,23 +910,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.1"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.1"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1582,9 +1597,9 @@ checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "sidevm"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c332fae24664d4162a1f4a9a68bbda5d26515360203b7f5a7f671a5f26fa833d"
+checksum = "92d0e6e61473fb78431dfb3f7de7eac5bbee283e57e1ecae1757ae689717cb25"
 dependencies = [
  "derive_more",
  "futures",
@@ -1594,16 +1609,15 @@ dependencies = [
  "parity-scale-codec",
  "pin-project",
  "sidevm-env",
- "sidevm-logger",
  "sidevm-macro",
  "tokio",
 ]
 
 [[package]]
 name = "sidevm-env"
-version = "0.2.0-alpha.6"
+version = "0.2.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b771372f5811c5f52d6506895dcfc3c274ff3e794ea87255d676c6a12691e772"
+checksum = "3a94444dfa5632606b8a49934b4b9db21e54a66d123a4874f831a0888382a297"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -1616,20 +1630,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sidevm-logger"
-version = "0.2.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811619a12237b546cbbd679a1335c79fc6c18d9229dff981d6c9000384d7d33"
-dependencies = [
- "log",
- "sidevm-env",
-]
-
-[[package]]
 name = "sidevm-macro"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6449f8bdaab34eab02a76052bcd8a8097949e511294ae55a98282b92d559dc68"
+checksum = "8533d2b2d177b17d53eb25e741c92bfa6860a132602f3094bdf2a8ebca72a2cc"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -1644,10 +1648,12 @@ dependencies = [
  "anyhow",
  "blake2",
  "bootcode",
+ "futures-util",
  "hex",
  "hyper",
  "hyper-rustls",
  "ink_macro",
+ "js-sys",
  "log",
  "parity-scale-codec",
  "pink-types",
@@ -1662,6 +1668,10 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
 ]
 
 [[package]]
@@ -1874,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
@@ -2022,6 +2032,95 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,16 +47,7 @@ reqwest = { version = "0.11.22", optional = true }
 [dependencies.web-sys]
 version = "0.3.4"
 optional = true
-features = [
-  'Headers',
-  'Request',
-  'RequestInit',
-  'RequestMode',
-  'Response',
-  'ReadableStream',
-  'Window',
-  'console',
-]
+features = ['Window', 'console']
 
 [features]
 default = ["native", "js-url", "js-http-listen", "js-hash"]
@@ -67,19 +58,13 @@ js-hash = ["sha2", "sha3", "blake2"]
 
 stream = ["js/stream"]
 sidevm = []
-web = [
-  "js-sys",
-  "web-sys",
-  "wasm-bindgen",
-  "wasm-bindgen-futures",
-  "reqwest",
-]
+web = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "reqwest"]
 
 native = [
-    "tokio/full",
-    "tracing-subscriber",
-    "rand",
-    "hyper/runtime",
-    "hyper/tcp",
-    "hyper-rustls/webpki-roots",
+  "tokio/full",
+  "tracing-subscriber",
+  "rand",
+  "hyper/runtime",
+  "hyper/tcp",
+  "hyper-rustls/webpki-roots",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ hyper = { version = "0.14", features = ["client", "http1"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 bootcode = { path = "bootcode" }
-sidevm = "0.2.0-alpha.5"
+sidevm = "0.2.0-alpha.7"
 log = "0.4"
 anyhow = "1.0"
 url = "2.4.0"
@@ -38,6 +38,27 @@ tracing-subscriber = { version = "0.3", optional = true }
 rand = { version = "0.8.5", optional = true }
 hyper-rustls = { version = "0.24.1", optional = true }
 
+# Creates for web backend
+wasm-bindgen = { version = "0.2.89", optional = true, default-features = false }
+js-sys = { version = "0.3.66", optional = true }
+wasm-bindgen-futures = { version = "0.4.39", optional = true }
+wasm-streams = { version = "0.4", optional = true }
+futures-util = "0.3.29"
+
+[dependencies.web-sys]
+version = "0.3.4"
+optional = true
+features = [
+  'Headers',
+  'Request',
+  'RequestInit',
+  'RequestMode',
+  'Response',
+  'ReadableStream',
+  'Window',
+  'console',
+]
+
 [features]
 default = ["native", "js-url", "js-http-listen", "js-hash"]
 sanitize-address = ["js/sanitize-address"]
@@ -46,6 +67,14 @@ js-http-listen = []
 js-hash = ["sha2", "sha3", "blake2"]
 
 stream = ["js/stream"]
+sidevm = []
+web = [
+  "js-sys",
+  "web-sys",
+  "wasm-bindgen",
+  "wasm-bindgen-futures",
+  "wasm-streams",
+]
 
 native = [
     "tokio/full",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,7 @@ hyper-rustls = { version = "0.24.1", optional = true }
 wasm-bindgen = { version = "0.2.89", optional = true, default-features = false }
 js-sys = { version = "0.3.66", optional = true }
 wasm-bindgen-futures = { version = "0.4.39", optional = true }
-wasm-streams = { version = "0.4", optional = true }
-futures-util = "0.3.29"
+reqwest = { version = "0.11.22", optional = true }
 
 [dependencies.web-sys]
 version = "0.3.4"
@@ -73,7 +72,7 @@ web = [
   "web-sys",
   "wasm-bindgen",
   "wasm-bindgen-futures",
-  "wasm-streams",
+  "reqwest",
 ]
 
 native = [

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,24 @@ PREFIX=~/bin
 BUILD_OUTPUT_DIR=target/wasm32-wasi/release
 BUILD_OUTPUT=$(addsuffix .wasm, $(TARGETS))
 OPTIMIZED_OUTPUT=$(addsuffix -stripped.wasm, $(TARGETS))
+WEB_BUILD_OUTPUT_DIR=target/wasm32-unknown-unknown/release
 
-.PHONY: all clean opt deep-clean install run test
+.PHONY: all clean opt deep-clean install run test web phatjs-web.wasm wasi
 
-all: $(BUILD_OUTPUT)
+all: wasi web
+wasi: $(BUILD_OUTPUT)
+web: phatjs-web.wasm
+	-wasm-bindgen phatjs-web.wasm  --out-dir l --typescript --target web --out-name index
 
 %.wasm:
-	cargo build --release --target wasm32-wasi --no-default-features --features js-hash
+	cargo build --release --target wasm32-wasi --no-default-features --features js-hash,sidevm
 	cp $(BUILD_OUTPUT_DIR)/$@ $@
 
-opt: $(OPTIMIZED_OUTPUT)
+phatjs-web.wasm:
+	cargo build --bin phatjs --release --target wasm32-unknown-unknown --no-default-features --features js-hash,web
+	cp $(WEB_BUILD_OUTPUT_DIR)/phatjs.wasm $@
+
+opt: all $(OPTIMIZED_OUTPUT)
 
 %-stripped.wasm: %.wasm
 	wasm-opt $< -Os -o $@
@@ -27,6 +35,7 @@ install: native
 
 clean:
 	rm -rf $(BUILD_OUTPUT_DIR)/*.wasm
+	rm -rf $(WEB_BUILD_OUTPUT_DIR)/*.wasm
 	rm -rf *.wasm
 
 deep-clean: clean

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ WEB_BUILD_OUTPUT_DIR=target/wasm32-unknown-unknown/release
 all: wasi web
 wasi: $(BUILD_OUTPUT)
 web: phatjs-web.wasm
-	-wasm-bindgen phatjs-web.wasm  --out-dir l --typescript --target web --out-name index
+	-wasm-bindgen phatjs-web.wasm  --out-dir web --typescript --target web --out-name index
 
 %.wasm:
 	cargo build --release --target wasm32-wasi --no-default-features --features js-hash,sidevm

--- a/bootcode/js/yarn.lock
+++ b/bootcode/js/yarn.lock
@@ -547,6 +547,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+abortcontroller-polyfill@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
+  integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
+
 acorn-import-assertions@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"

--- a/src/host_functions.rs
+++ b/src/host_functions.rs
@@ -7,13 +7,6 @@ use crate::traits::ResultExt;
 
 #[cfg(feature = "js-http-listen")]
 pub(crate) use http_listen::try_accept_http_request;
-#[cfg(not(feature = "js-http-listen"))]
-pub(crate) fn try_accept_http_request(
-    _service: ServiceRef,
-    _request: crate::runtime::HttpRequest,
-) -> Result<()> {
-    Ok(())
-}
 
 mod debug;
 #[cfg(feature = "js-http-listen")]

--- a/src/host_functions/http_request.rs
+++ b/src/host_functions/http_request.rs
@@ -1,15 +1,11 @@
-use anyhow::Context;
-use hyper::{body::HttpBody, Body};
+use anyhow::anyhow;
 use log::info;
 use std::{
     collections::{BTreeMap, BTreeSet},
     time::Duration,
 };
 
-use crate::{
-    runtime::{http_connector, time::timeout, HyperExecutor},
-    service::OwnedJsValue,
-};
+use crate::{runtime::time::sleep, service::OwnedJsValue};
 use js::{AsBytes, Error as ValueError, FromJsValue, ToJsValue};
 
 use super::*;
@@ -118,16 +114,32 @@ fn default_timeout() -> u64 {
 
 async fn do_http_request(weak_service: ServiceWeakRef, id: u64, req: HttpRequest) {
     let url = req.url.clone();
-    let result = do_http_request_inner(weak_service.clone(), id, req).await;
+    let result = tokio::select! {
+        _ = sleep(Duration::from_millis(req.timeout_ms)) => {
+            Err(anyhow!("Timed out"))
+        }
+        result = do_http_request_inner(weak_service.clone(), id, req) => result,
+    };
     if let Err(err) = result {
-        invoke_callback(&weak_service, id, "error", &format!("Failed to request `{url}`: {err:?}"));
+        invoke_callback(
+            &weak_service,
+            id,
+            "error",
+            &format!("Failed to request `{url}`: {err:?}"),
+        );
     }
 }
+
+#[cfg(not(feature = "web"))]
 async fn do_http_request_inner(
     weak_service: ServiceWeakRef,
     id: u64,
     req: HttpRequest,
 ) -> Result<()> {
+    use crate::runtime::{http_connector, HyperExecutor};
+    use anyhow::Context;
+    use core::pin::pin;
+    use hyper::{body::HttpBody, Body};
     let connector = http_connector();
     let client = hyper::Client::builder()
         .executor(HyperExecutor)
@@ -161,12 +173,7 @@ async fn do_http_request_inner(
     let request = builder
         .body(Body::from(body))
         .context("Failed to build request")?;
-    let response = timeout(
-        Duration::from_millis(req.timeout_ms),
-        client.request(request),
-    )
-    .await
-    .context("Timed out")??;
+    let response = client.request(request).await?;
     {
         let head = {
             let headers = response
@@ -190,10 +197,98 @@ async fn do_http_request_inner(
         };
         invoke_callback(&weak_service, id, "head", &head);
     }
-    tokio::pin!(response);
+    let mut response = pin!(response);
     while let Some(chunk) = response.data().await {
         let chunk = chunk.context("Failed to read response body")?;
         invoke_callback(&weak_service, id, "data", &AsBytes(chunk));
+    }
+    invoke_callback(&weak_service, id, "end", &());
+    Ok(())
+}
+
+#[cfg(feature = "web")]
+async fn do_http_request_inner(
+    weak_service: ServiceWeakRef,
+    id: u64,
+    req: HttpRequest,
+) -> Result<()> {
+    web_do_http_request_inner(weak_service, id, req)
+        .await
+        .map_err(|err| match err.as_string() {
+            Some(err) => anyhow!("{err}"),
+            None => anyhow!("Unknown exception: failed to convert error to string"),
+        })
+}
+
+#[cfg(feature = "web")]
+async fn web_do_http_request_inner(
+    weak_service: ServiceWeakRef,
+    id: u64,
+    req: HttpRequest,
+) -> Result<(), wasm_bindgen::JsValue> {
+    use futures_util::stream::StreamExt;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+    use wasm_streams::ReadableStream;
+    use web_sys::{Request, RequestInit, Response};
+
+    let mut opts = RequestInit::new();
+    opts.method(&req.method);
+    let body: Vec<u8> = if let Some(text_body) = req.text_body {
+        text_body.into_bytes()
+    } else {
+        req.body
+    };
+    if body.len() > 0 {
+        opts.body(Some(&js_sys::Uint8Array::from(body.as_slice()).into()));
+    }
+
+    let url = req.url;
+    let request = Request::new_with_str_and_init(&url, &opts)?;
+
+    for (k, v) in req.headers.pairs.iter() {
+        request.headers().set(k, v)?;
+    }
+    let headers: BTreeSet<&str> = req.headers.pairs.iter().map(|(k, _v)| k.as_str()).collect();
+    // Append Host, Content-Length and Content-Length if not present
+    if !headers.contains("User-Agent") {
+        request.headers().set("User-Agent", "PhatContract/0.1.0")?;
+    }
+
+    let window = web_sys::window().unwrap();
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
+
+    // `resp_value` is a `Response` object.
+    assert!(resp_value.is_instance_of::<Response>());
+    let resp: Response = resp_value.dyn_into().unwrap();
+
+    let head = {
+        // TODO: fill headers
+        // let headers = resp
+        //     .headers()
+        //     .iter()
+        //     .map(|(k, v)| (k.into(), v.into()))
+        //     .collect();
+        let status = resp.status();
+        let status_text = resp.status_text();
+        HttpResponseHead {
+            status,
+            status_text,
+            version: "HTTP/1.1".into(),
+            headers: Headers::default(),
+        }
+    };
+    invoke_callback(&weak_service, id, "head", &head);
+
+    // Convert this other `Promise` into a rust `Future`.
+    if let Some(body) = resp.body() {
+        let body = ReadableStream::from_raw(body);
+        // Convert the JS ReadableStream to a Rust stream
+        let mut stream = body.into_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = js_sys::Uint8Array::new(&chunk?).to_vec();
+            invoke_callback(&weak_service, id, "data", &AsBytes(chunk));
+        }
     }
     invoke_callback(&weak_service, id, "end", &());
     Ok(())

--- a/src/js_eval.rs
+++ b/src/js_eval.rs
@@ -1,0 +1,115 @@
+use js::ToJsValue;
+
+use crate::Service;
+use anyhow::{anyhow, bail, Context, Result};
+
+use pink_types::js::{JsCode, JsValue};
+
+struct Args {
+    codes: Vec<JsCode>,
+    js_args: Vec<String>,
+}
+
+fn parse_args(args: impl Iterator<Item = String>) -> Result<Args> {
+    let mut codes = vec![];
+    let mut iter = args;
+    iter.next();
+    while let Some(arg) = iter.next() {
+        if arg.starts_with("-") {
+            if arg == "--" {
+                break;
+            }
+            match arg.as_str() {
+                "-c" => {
+                    let code = iter.next().ok_or(anyhow!("Missing code after -c"))?;
+                    codes.push(JsCode::Source(code));
+                }
+                "-b" => {
+                    let code = iter.next().ok_or(anyhow!("Missing code after -b"))?;
+                    let bytecode = hex::decode(code).context("Failed to decode bytecode")?;
+                    codes.push(JsCode::Bytecode(bytecode));
+                }
+                _ => {
+                    print_usage();
+                    bail!("Unknown option: {}", arg);
+                }
+            }
+        } else {
+            // File name
+            let code = std::fs::read_to_string(arg).context("Failed to read script file")?;
+            codes.push(JsCode::Source(code));
+        }
+    }
+    if codes.is_empty() {
+        print_usage();
+        bail!("No script file provided");
+    }
+    let js_args = iter.collect();
+    Ok(Args { codes, js_args })
+}
+
+fn print_usage() {
+    println!("Usage: phatjs [options] [script..] [-- [args]]");
+    println!("");
+    println!("Options:");
+    println!("  -c <code>        Execute code");
+    println!("  -b <hexed code>  Execute bytecode");
+    println!("  --               Stop processing options");
+}
+
+pub async fn run(args: impl Iterator<Item = String>) -> Result<JsValue> {
+    let args = parse_args(args)?;
+    let service = Service::new_ref();
+    let js_ctx = service.context();
+    let js_args = args
+        .js_args
+        .to_js_value(&js_ctx)
+        .context("Failed to convert args to js value")?;
+    js_ctx
+        .get_global_object()
+        .set_property("scriptArgs", &js_args)
+        .context("Failed to set scriptArgs")?;
+    let mut expr_val = None;
+    for code in args.codes.into_iter() {
+        let result = match code {
+            JsCode::Source(src) => service.exec_script(&src),
+            JsCode::Bytecode(bytes) => service.exec_bytecode(&bytes),
+        };
+        match result {
+            Ok(value) => expr_val = value.to_js_value(),
+            Err(err) => {
+                bail!("Failed to execute script: {err}");
+            }
+        }
+    }
+    if service.number_of_tasks() > 0 {
+        service.wait_for_tasks().await;
+    }
+    // If scriptOutput is set, use it as output. Otherwise, use the last expression value.
+    let output = js_ctx
+        .get_global_object()
+        .get_property("scriptOutput")
+        .unwrap_or_default();
+    let output = if output.is_undefined() {
+        expr_val.unwrap_or_default()
+    } else {
+        output
+    };
+    convert(output).context("Failed to convert output")
+}
+
+fn convert(output: js::Value) -> Result<JsValue> {
+    if output.is_undefined() {
+        return Ok(JsValue::Undefined);
+    }
+    if output.is_null() {
+        return Ok(JsValue::Null);
+    }
+    if output.is_string() {
+        return Ok(JsValue::String(output.decode_string()?));
+    }
+    if output.is_uint8_array() {
+        return Ok(JsValue::Bytes(output.decode_bytes()?));
+    }
+    return Ok(JsValue::Other(output.to_string()));
+}

--- a/src/phatjs.rs
+++ b/src/phatjs.rs
@@ -2,137 +2,58 @@
 
 extern crate alloc;
 
-use js::ToJsValue;
+#[cfg(not(feature = "web"))]
+mod cli {
+    use sidevm_quickjs::{js_eval::run, runtime};
 
-use anyhow::{anyhow, bail, Context, Result};
-use sidevm_quickjs::{runtime, Service};
-
-use pink_types::js::{JsCode, JsValue};
-
-struct Args {
-    codes: Vec<JsCode>,
-    js_args: Vec<String>,
-}
-
-fn parse_args() -> Result<Args> {
-    let mut codes = vec![];
-    let mut iter = std::env::args();
-    iter.next();
-    while let Some(arg) = iter.next() {
-        if arg.starts_with("-") {
-            if arg == "--" {
-                break;
-            }
-            match arg.as_str() {
-                "-c" => {
-                    let code = iter.next().ok_or(anyhow!("Missing code after -c"))?;
-                    codes.push(JsCode::Source(code));
-                }
-                "-b" => {
-                    let code = iter.next().ok_or(anyhow!("Missing code after -b"))?;
-                    let bytecode = hex::decode(code).context("Failed to decode bytecode")?;
-                    codes.push(JsCode::Bytecode(bytecode));
-                }
-                _ => {
-                    print_usage();
-                    bail!("Unknown option: {}", arg);
-                }
-            }
-        } else {
-            // File name
-            let code = std::fs::read_to_string(arg).context("Failed to read script file")?;
-            codes.push(JsCode::Source(code));
-        }
+    #[runtime::main]
+    async fn main() {
+        use pink_types::js::JsValue;
+        runtime::init_logger();
+        runtime::run_local(async {
+            let output = match run(std::env::args()).await {
+                Ok(value) => value,
+                Err(err) => JsValue::Exception(err.to_string()),
+            };
+            #[cfg(feature = "native")]
+            log::info!("Script output: {:?}", output);
+            #[cfg(not(feature = "native"))]
+            sidevm::ocall::emit_program_output(&scale::Encode::encode(&output))
+                .expect("Failed to emit program output");
+        })
+        .await;
     }
-    if codes.is_empty() {
-        print_usage();
-        bail!("No script file provided");
+}
+#[cfg(feature = "web")]
+mod web {
+    use sidevm_quickjs::{js_eval, runtime::init_logger};
+
+    use pink_types::js::JsValue as QjsValue;
+    use wasm_bindgen::JsValue as WebJsValue;
+
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub async fn version() -> String {
+        env!("CARGO_PKG_VERSION").to_string()
     }
-    let js_args = iter.collect();
-    Ok(Args { codes, js_args })
-}
 
-fn print_usage() {
-    println!("Usage: phatjs [options] [script..] [-- [args]]");
-    println!("");
-    println!("Options:");
-    println!("  -c <code>        Execute code");
-    println!("  -b <hexed code>  Execute bytecode");
-    println!("  --               Stop processing options");
-}
-
-async fn run() -> Result<JsValue> {
-    let args = parse_args()?;
-    let service = Service::new_ref();
-    let js_ctx = service.context();
-    let js_args = args
-        .js_args
-        .to_js_value(&js_ctx)
-        .context("Failed to convert args to js value")?;
-    js_ctx
-        .get_global_object()
-        .set_property("scriptArgs", &js_args)
-        .context("Failed to set scriptArgs")?;
-    let mut expr_val = None;
-    for code in args.codes.into_iter() {
-        let result = match code {
-            JsCode::Source(src) => service.exec_script(&src),
-            JsCode::Bytecode(bytes) => service.exec_bytecode(&bytes),
-        };
+    #[wasm_bindgen::prelude::wasm_bindgen]
+    pub async fn run(args: Vec<String>) -> Result<WebJsValue, WebJsValue> {
+        init_logger();
+        let result = js_eval::run(args.into_iter()).await;
         match result {
-            Ok(value) => expr_val = value.to_js_value(),
-            Err(err) => {
-                bail!("Failed to execute script: {err}");
-            }
+            Ok(value) => Ok({
+                match value {
+                    QjsValue::Undefined => WebJsValue::UNDEFINED,
+                    QjsValue::Null => WebJsValue::NULL,
+                    QjsValue::String(v) => v.into(),
+                    QjsValue::Other(v) => v.into(),
+                    QjsValue::Bytes(v) => js_sys::Uint8Array::from(v.as_slice()).into(),
+                    QjsValue::Exception(err) => return Err(err.into()),
+                }
+            }),
+            Err(err) => Err(err.to_string().into()),
         }
     }
-    if service.number_of_tasks() > 0 {
-        service.wait_for_tasks().await;
-    }
-    // If scriptOutput is set, use it as output. Otherwise, use the last expression value.
-    let output = js_ctx
-        .get_global_object()
-        .get_property("scriptOutput")
-        .unwrap_or_default();
-    let output = if output.is_undefined() {
-        expr_val.unwrap_or_default()
-    } else {
-        output
-    };
-    convert(output).context("Failed to convert output")
-}
-
-fn convert(output: js::Value) -> Result<JsValue> {
-    if output.is_undefined() {
-        return Ok(JsValue::Undefined);
-    }
-    if output.is_null() {
-        return Ok(JsValue::Null);
-    }
-    if output.is_string() {
-        return Ok(JsValue::String(output.decode_string()?));
-    }
-    if output.is_uint8_array() {
-        return Ok(JsValue::Bytes(output.decode_bytes()?));
-    }
-    return Ok(JsValue::Other(output.to_string()));
-}
-
-#[runtime::main]
-async fn main() {
-    runtime::init_logger();
-    runtime::run_local(async {
-        let output = match run().await {
-            Ok(value) => value,
-            Err(err) => JsValue::Exception(err.to_string()),
-        };
-        #[cfg(feature = "native")]
-        log::info!("Script output: {:?}", output);
-        #[cfg(not(feature = "native"))]
-        sidevm::ocall::emit_program_output(&scale::Encode::encode(&output))
-            .expect("Failed to emit program output");
-    })
-    .await;
 }
 
 #[cfg(not(feature = "native"))]


### PR DESCRIPTION
There is an issue with the wasm-bindgen tool for generating JavaScript bindings:
```
wasm-bindgen phatjs-web.wasm  --out-dir . --typescript --target web --out-name index
[2023-12-11T13:14:16Z WARN  walrus::module] in name section: index `0` is out of bounds for data
[2023-12-11T13:14:16Z WARN  walrus::module] in name section: index `1` is out of bounds for data
thread 'main' panicked at 'unknown instruction Block(Block { seq: Id { idx: 1 } })', /home/kvin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-wasm-interpreter-0.2.89/src/lib.rs:367:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
More info: https://github.com/rustwasm/wasm-bindgen/issues/3315
